### PR TITLE
Update med.py: Fixed the issue of BERTEncoder.forward() not returning cross-attentions when requested

### DIFF
--- a/models/med.py
+++ b/models/med.py
@@ -458,6 +458,8 @@ class BertEncoder(nn.Module):
                 next_decoder_cache += (layer_outputs[-1],)
             if output_attentions:
                 all_self_attentions = all_self_attentions + (layer_outputs[1],)
+                if self.config.add_cross_attention:
+                    all_cross_attentions = all_cross_attentions + (layer_outputs[2],)
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)


### PR DESCRIPTION
Update med.py: Fixed the issue of BERTEncoder.forward() not returning cross-attentions when requested

In class BertEncoder.forward() method, `all_cross_attentions` is defined in Line 409, but not maintained, which causes a retuning of None object when requested. In this revision, `all_cross_attentions` is properly updated and maintained in Line 461. The maintenance code is referred from the original Hugging-face Transformer library https://github.com/huggingface/transformers/blob/v4.15.0/src/transformers/models/bert/modeling_bert.py Line600, and is tested to be valid.